### PR TITLE
update organisation name in actions

### DIFF
--- a/.github/workflows/check-truth.yml
+++ b/.github/workflows/check-truth.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-latest
     env:
       RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"

--- a/.github/workflows/create-parquet.yml
+++ b/.github/workflows/create-parquet.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   create-parquet:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ecdc_owid_data.yml
+++ b/.github/workflows/ecdc_owid_data.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   get_data:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ensemble.yml
+++ b/.github/workflows/ensemble.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ensemble:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -9,7 +9,7 @@ name: Render README
 
 jobs:
   render:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     name: Render README
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/reports-country.yml
+++ b/.github/workflows/reports-country.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   country_reports:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/reports-model.yml
+++ b/.github/workflows/reports-model.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   model_reports:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/scoring.yml
+++ b/.github/workflows/scoring.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 9 * * 1"
 jobs:
   scores:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visualisation.yml
+++ b/.github/workflows/visualisation.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   create-files:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zoltar-upload.yml
+++ b/.github/workflows/zoltar-upload.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'covid19-forecast-hub-europe'
+    if: github.repository_owner == 'european-modelling-hubs'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The github Actions workflows have a check for the organisation names to ensure actions aren't run in forks. This PR updates this check to use the updated organisation name.