### PR TITLE
fix ICM forecast of 8/1/24

### DIFF
--- a/data-processed/ICM-agentModel/2024-01-08-ICM-agentModel.csv
+++ b/data-processed/ICM-agentModel/2024-01-08-ICM-agentModel.csv
@@ -191,4 +191,3 @@ forecast_date,target,target_end_date,location,type,quantile,value,scenario_id
 2024-01-08,4 wk ahead inc death,2024-02-03,PL,quantile,0.95,68,forecast
 2024-01-08,4 wk ahead inc death,2024-02-03,PL,quantile,0.975,73,forecast
 2024-01-08,4 wk ahead inc death,2024-02-03,PL,quantile,0.99,79,forecast
-       


### PR DESCRIPTION
The ICM forecast of 8/1/24 was merged despite [not passing validation](https://github.com/european-modelling-hubs/covid19-forecast-hub-europe/actions/runs/7453247828/job/20304071596). This fixes the file by remove the final line.

Tagging for info @reneniehus @macrad.