### PR TITLE
add legacy truth data to plotting

### DIFF
--- a/viz/prepare_truth_data.R
+++ b/viz/prepare_truth_data.R
@@ -6,15 +6,26 @@ library(tidyr)
 
 # FIXME: find a way to get this information directly from the config file
 # without hardcoding target types
-truth <- c(
+var_files <- c(
   "inc_death" = "ECDC/truth_ECDC-Incident Deaths.csv",
   "inc_case" = "ECDC/truth_ECDC-Incident Cases.csv",
   "inc_hosp" = "OWID/truncated_OWID-Incident Hospitalizations.csv"
-) |>
+)
+truth <- var_files |>
   imap(~ read_csv(here("data-truth", .x)) %>% mutate(name = .y)) |>
   bind_rows()
 
+# get legacty data
+legacy <- c("ECDC/final/", "OWID/final") |>
+  map(~ tail(list.files(here("data-truth", .x), full.names = TRUE), 1)) |>
+  map(~ read_csv(.x, show_col_types = FALSE)) |>
+  bind_rows() |>
+  mutate(name = gsub(" ", "_", target_variable)) |>
+  filter(name %in% names(var_files)) |>
+  anti_join(truth, by = c("location_name", "location", "date", "name"))
+
 truth <- truth |>
+  bind_rows(legacy) |>
   # add epi weeks for aggregation
   mutate(date = lubridate::ymd(date),
          epi_week = lubridate::epiweek(date),


### PR DESCRIPTION
Currently data that hasn't been updated for 4 weeks is not forwarded to the visualisation platform on the web site, which breaks some of the functionality there.

This PR adds legacy truth data to the web site visualisations.